### PR TITLE
Move bash completion script to /usr/share/bash-completion/completions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(name='apt_venv',
           ('share/man/man1', ['man/apt-venv.1']),
           ('share/doc/apt-venv', ['README.md', 'AUTHORS']),
           ('/etc', ['etc/apt-venv.conf']),
-          ('/etc/bash_completion.d', ['etc/bash_completion.d/apt-venv'])
+          ('/usr/share/bash-completion/completions',
+           ['share/bash-completion/completions/apt-venv'])
       ],
       )

--- a/share/bash-completion/completions/apt-venv
+++ b/share/bash-completion/completions/apt-venv
@@ -1,4 +1,3 @@
-have apt-venv &&
 _apt-venv()
 {
     local cur prev options


### PR DESCRIPTION
Hi Leo!

As per https://github.com/scop/bash-completion/blob/master/README.md, `/etc/bash_completion.d` is deprecated and completions should be installed under the `completionsdir`, which point to `/usr/share/bash-completion/completions`.

I've updated setup.py to install the completion in the correct directory, moved the completion according to the new path and removed the `have apt-venv` check, which would prevent the completion from loading correctly.